### PR TITLE
Update eslint peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"eslint-plugin-unicorn": "^37.0.1"
 	},
 	"peerDependencies": {
-		"eslint": "^7.32.0",
+		"eslint": ">=7",
 		"eslint-plugin-vue": "^7.8.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Having `"^7.32.0"` eslint peer dependency means projects with eslint v8 do not work with this package