### PR TITLE
Update eslint-plugin-modules-newlines plugin

### DIFF
--- a/eslint-config-zyro.js
+++ b/eslint-config-zyro.js
@@ -7,7 +7,7 @@ const {
 module.exports = {
 	plugins: [
 		'import',
-		'modules-newline',
+		'modules-newlines',
 		'destructuring-newline',
 		'destructure-depth',
 		'unicorn',
@@ -40,8 +40,8 @@ module.exports = {
 			},
 		],
 		'import/prefer-default-export': 'off',
-		'modules-newline/import-declaration-newline': 'error',
-		'modules-newline/export-declaration-newline': 'error',
+		'modules-newlines/import-declaration-newline': 'error',
+		'modules-newlines/export-declaration-newline': 'error',
 		'no-restricted-imports': [
 			'error',
 			{

--- a/package-lock.json
+++ b/package-lock.json
@@ -943,10 +943,10 @@
 				"tsconfig-paths": "^3.11.0"
 			}
 		},
-		"eslint-plugin-modules-newline": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-modules-newline/-/eslint-plugin-modules-newline-0.0.6.tgz",
-			"integrity": "sha512-69NpBr68U6pmXL+y+KHl/64PwRarceC3/sCNUVxRbe0gPI32SIw8AtdpkqNiJYCa2yMd4lRrkrnU09Yio7KVzA==",
+		"eslint-plugin-modules-newlines": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-modules-newlines/-/eslint-plugin-modules-newlines-0.0.7.tgz",
+			"integrity": "sha512-EYRsG/b0pgV6AG4C321G7Mv9INP526G+R+tLbPZMlJxGqE06Xnh+kYJeDDKn2Dp5XnmpyNON74wyDTKbyInZDg==",
 			"requires": {
 				"requireindex": "~1.1.0"
 			}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"eslint-plugin-destructure-depth": "^1.0.2",
 		"eslint-plugin-destructuring-newline": "^0.0.2",
 		"eslint-plugin-import": "^2.25.2",
-		"eslint-plugin-modules-newline": "^0.0.6",
+		"eslint-plugin-modules-newlines": "^0.0.7",
 		"eslint-plugin-unicorn": "^37.0.1"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zyro-inc/eslint-config-zyro",
-	"version": "1.0.17",
+	"version": "1.0.18",
 	"description": "ESLint config, which follows the Zyro style guide",
 	"main": "index.js",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"eslint-plugin-destructure-depth": "^1.0.2",
 		"eslint-plugin-destructuring-newline": "^0.0.2",
 		"eslint-plugin-import": "^2.25.2",
-		"eslint-plugin-modules-newlines": "^0.0.7",
+		"eslint-plugin-modules-newlines": "0.0.7",
 		"eslint-plugin-unicorn": "^37.0.1"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"eslint-plugin-destructure-depth": "^1.0.2",
 		"eslint-plugin-destructuring-newline": "^0.0.2",
 		"eslint-plugin-import": "^2.25.2",
-		"eslint-plugin-modules-newlines": "0.0.7",
+		"eslint-plugin-modules-newlines": "^0.0.7",
 		"eslint-plugin-unicorn": "^37.0.1"
 	},
 	"peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -644,10 +644,10 @@ eslint-plugin-import@^2.25.2:
     resolve "^1.20.0"
     tsconfig-paths "^3.11.0"
 
-eslint-plugin-modules-newline@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-modules-newline/-/eslint-plugin-modules-newline-0.0.6.tgz#310093ee8656efe92a8c6f9cb3aa5df9fea6331c"
-  integrity sha512-69NpBr68U6pmXL+y+KHl/64PwRarceC3/sCNUVxRbe0gPI32SIw8AtdpkqNiJYCa2yMd4lRrkrnU09Yio7KVzA==
+eslint-plugin-modules-newlines@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-modules-newlines/-/eslint-plugin-modules-newlines-0.0.7.tgz#f5a751fcea232e14c108f1917ebd565bab4435de"
+  integrity sha512-EYRsG/b0pgV6AG4C321G7Mv9INP526G+R+tLbPZMlJxGqE06Xnh+kYJeDDKn2Dp5XnmpyNON74wyDTKbyInZDg==
   dependencies:
     requireindex "~1.1.0"
 


### PR DESCRIPTION
We need to update the plugin because `eslint-plugin-modules-newline` throws an error in eslint v8 as it does not have `meta.fixable` property. The package itself is old and no one updates it now, so there's little chance that it would be fixed, so there's a fork of that package `eslint-plugin-modules-newlines` which fixes that exact issue.